### PR TITLE
Fix socket connection issue

### DIFF
--- a/vnav_acquisition/comm.py
+++ b/vnav_acquisition/comm.py
@@ -25,7 +25,6 @@ def on_rec_start(connection, username, material, speed, delay=0.05):
     global remote_path
     file_name = f"{username}_{material}_{speed}_{time.strftime('%Y-%m-%d_%H.%M.%S', time.localtime())}.wav"
     if ssh is None:
-        ssh_connect("raspberrypi", 22, "pi", "VibroNav")
         ssh_connect(*connection)
         time.sleep(1)
     play_chirp_signal(delay)


### PR DESCRIPTION
This line caused a socket connection error since the code connected to the raspberry twice and the socket was marked as used. We are taking the connection parameters from the config regardless. 
The error made it impossible to make recordings.