### PR TITLE
Fix ffmpeg bug on MacOS

### DIFF
--- a/vnav_acquisition/sync.py
+++ b/vnav_acquisition/sync.py
@@ -19,12 +19,13 @@ def extract_audio_from_video(video_file: str) -> [int, np.ndarray]:
 
         # execute FFmpeg from PowerShell
         try:
-            subprocess.run(ffmpeg_command, check=True, shell=True)
+            subprocess.run(ffmpeg_command)
             fs, x = read_wave(tmp_wav_file)
             os.remove(tmp_wav_file)
             return fs, x
         except subprocess.CalledProcessError as e:
             print(f'Error while executing FFmpeg: {e}')
+            raise e
 
 
 def argmax_correlation(input_signal, sync_signal):


### PR DESCRIPTION
- fix shell process error on MacOS
- raise error so that the script exits instead of continues when there is an error with ffmpeg (this helps debugging)